### PR TITLE
Removed exception in default ILocatorAmbient implementation.

### DIFF
--- a/src/DotNetStarter/DotNetStarter.csproj
+++ b/src/DotNetStarter/DotNetStarter.csproj
@@ -6,12 +6,12 @@
 
   <PropertyGroup>
     <PackageId>DotNetStarter</PackageId>
-    <TargetFrameworks>net35;net40;net45;netstandard1.0;netstandard1.1;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard1.0;netstandard1.6;netstandard2.0</TargetFrameworks>
     <Authors>Brad McDavid</Authors>
     <Copyright>Copyright $(CurrentYear)</Copyright>
     <Description>Startup system and service registration for a DI container.</Description>
     <!--follow semantic versioning may include prelease information too-->
-    <PackageVersion>2.2.1</PackageVersion>
+    <PackageVersion>2.2.2</PackageVersion>
     <PackageTags>Startup Modules DI</PackageTags>
 
     <!--do not change unless you want to deal with assembly redirects-->
@@ -22,14 +22,6 @@
   <Import Project="..\..\targets\CommonNuGetPackage.props" />
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.0" />
   </ItemGroup>
 
@@ -51,14 +43,6 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0'">
     <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.1'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6'">

--- a/src/DotNetStarter/Internal/AssemblyLoader.cs
+++ b/src/DotNetStarter/Internal/AssemblyLoader.cs
@@ -70,9 +70,9 @@ namespace DotNetStarter.Internal
         }
 #endif
 
-#if NETSTANDARD1_0 || NETSTANDARD1_1 || NETSTANDARD1_3
+#if NETSTANDARD1_0
         /// <summary>
-        /// Assembly loader not implemented for netstandard
+        /// Assembly loader not implemented for netstandard 1.0
         /// </summary>
         /// <returns></returns>
         public virtual IEnumerable<Assembly> GetAssemblies()

--- a/src/DotNetStarter/Internal/LocatorAmbient.cs
+++ b/src/DotNetStarter/Internal/LocatorAmbient.cs
@@ -48,10 +48,6 @@ namespace DotNetStarter.Internal
             if (scopedLocator == null && stack.Count > 0) { stack.Pop(); }
             // push newest scope to top
             else if (scopedLocator != null) { stack.Push(scopedLocator); }
-            else
-            {
-                throw new Exception("Null locator tried to add to remove from empty stack, or null tried to add to stack!");
-            }
             SetStack(stack);
         }
 
@@ -68,7 +64,7 @@ namespace DotNetStarter.Internal
         {
             System.Runtime.Remoting.Messaging.CallContext.SetData(Key, stack);
         }
-#elif NETSTANDARD2_0 || NETSTANDARD1_3 || NETSTANDARD1_6
+#elif NETSTANDARD2_0 || NETSTANDARD1_6
         // based on httpcontextaccessor
         private static readonly System.Threading.AsyncLocal<Stack<ILocatorScoped>> LocatorScopedContext = new System.Threading.AsyncLocal<Stack<ILocatorScoped>>();
 
@@ -84,12 +80,12 @@ namespace DotNetStarter.Internal
 #else
         private static Stack<ILocatorScoped> GetStack()
         {
-            throw new NotSupportedException("ILocatorAmbient not supported in netstandard1.0 and netstandard1.1!");
+            throw new NotSupportedException("ILocatorAmbient not supported in netstandard1.0!");
         }
 
         private static void SetStack(Stack<ILocatorScoped> stack)
         {
-            throw new NotSupportedException("ILocatorAmbient not supported in netstandard1.0 and netstandard1.1!");
+            throw new NotSupportedException("ILocatorAmbient not supported in netstandard1.0!");
         }
 #endif
     }

--- a/src/DotNetStarter/releasenotes.txt
+++ b/src/DotNetStarter/releasenotes.txt
@@ -1,2 +1,2 @@
-﻿Added netstandard 1.6 support.
-Fixing known issues for netcore applications.
+﻿Removed exception in default ILocatorAmbient implementation.
+Removed netstandard1.1 and netstandard1.3 from DotNetStarter as they were redundant in the matrix.


### PR DESCRIPTION
Removed netstandard1.1 and netstandard1.3 from DotNetStarter as they were redundant in the matrix.